### PR TITLE
replace "..." to h1 element

### DIFF
--- a/src/templates/WordPressCategory.vue
+++ b/src/templates/WordPressCategory.vue
@@ -1,6 +1,6 @@
 <template>
   <Layout>
-    ...
+    <h1 v-html="$page.wordPressPostTag.title"/>    
   </Layout>
 </template>
 

--- a/src/templates/WordPressCategory.vue
+++ b/src/templates/WordPressCategory.vue
@@ -1,6 +1,6 @@
 <template>
   <Layout>
-    <h1 v-html="$page.wordPressPostTag.title"/>    
+    <h1 v-html="$page.wordPressPostTag.title"/>
   </Layout>
 </template>
 

--- a/src/templates/WordPressPostTag.vue
+++ b/src/templates/WordPressPostTag.vue
@@ -1,6 +1,6 @@
 <template>
   <Layout>
-    ...
+    <h1 v-html="$page.wordPressPostTag.title"/>    
   </Layout>
 </template>
 

--- a/src/templates/WordPressPostTag.vue
+++ b/src/templates/WordPressPostTag.vue
@@ -1,6 +1,6 @@
 <template>
   <Layout>
-    <h1 v-html="$page.wordPressPostTag.title"/>    
+    <h1 v-html="$page.wordPressPostTag.title"/>
   </Layout>
 </template>
 


### PR DESCRIPTION
I replaced "..." in the target file with a h1 element. That is because the specification fits WordPressPost.vue.

novices will not confuse by "..."
maybe :)
