### PR TITLE
Update to @gridsome/source-wordpress ^0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "gridsome build"
   },
   "dependencies": {
-    "@gridsome/source-wordpress": "^0.4.0",
+    "@gridsome/source-wordpress": "^0.5.0",
     "gridsome": "^0.7.0"
   }
 }


### PR DESCRIPTION
Bumped `@gridsome/source-wordpress` from 0.4 to 0.5 (for custom rest endpoints).